### PR TITLE
fix(ui): dropdowns del form — recuadro visible y sin recorte en acordeones

### DIFF
--- a/frontend/src/components/Admin/Properties/PropertyCreatePage.css
+++ b/frontend/src/components/Admin/Properties/PropertyCreatePage.css
@@ -51,13 +51,14 @@
   border-bottom: none;
 }
 
-/* Acordeón de secciones avanzadas (divulgación progresiva) */
+/* Acordeón de secciones avanzadas (divulgación progresiva).
+   Sin overflow:hidden para no recortar los dropdowns (CustomSelect) que se
+   despliegan por debajo del contenido del acordeón. */
 .form-accordion {
   border: 1px solid var(--color-neutral-200);
   border-radius: var(--radius-md);
   margin-top: var(--spacing-md);
   background: var(--color-neutral-50);
-  overflow: hidden;
 }
 
 .form-accordion__summary {

--- a/frontend/src/components/CustomSelect/CustomSelect.css
+++ b/frontend/src/components/CustomSelect/CustomSelect.css
@@ -69,6 +69,43 @@
   color: var(--color-brand-primary);
 }
 
+/* En el formulario de admin el select se ve como un input de formulario
+   (recuadro con borde/fondo) para que se perciba como control seleccionable. */
+.property-create-page .custom-select {
+  border: 1px solid var(--color-neutral-300);
+  border-radius: var(--radius-md);
+  background: var(--color-neutral-0);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.property-create-page .custom-select-trigger {
+  padding: 0.75rem;
+}
+
+.property-create-page .custom-select-value {
+  text-align: left;
+  color: var(--color-neutral-800);
+}
+
+.property-create-page .custom-select-value--placeholder {
+  color: var(--color-neutral-400);
+}
+
+/* En el form el texto no se tiñe de azul al hover; solo cambia el borde */
+.property-create-page .custom-select:hover {
+  border-color: var(--color-neutral-400);
+}
+
+.property-create-page .custom-select:hover .custom-select-trigger {
+  color: var(--color-neutral-800);
+}
+
+.property-create-page .custom-select.open,
+.property-create-page .custom-select:focus-within {
+  border-color: var(--color-brand-primary);
+  box-shadow: var(--focus-ring);
+}
+
 /* Dropdown */
 .custom-select-dropdown {
   position: absolute;

--- a/frontend/src/components/CustomSelect/CustomSelect.jsx
+++ b/frontend/src/components/CustomSelect/CustomSelect.jsx
@@ -145,7 +145,7 @@ const CustomSelect = ({
         aria-haspopup="listbox"
         aria-disabled={disabled}
       >
-        <span className="custom-select-value">
+        <span className={`custom-select-value${selectedOption ? '' : ' custom-select-value--placeholder'}`}>
           {selectedOption ? selectedOption.label : placeholder}
         </span>
         <div className={`custom-select-arrow ${isOpen ? 'rotated' : ''}`}>


### PR DESCRIPTION
Arreglo de UI de los dropdowns (`CustomSelect`) del formulario de crear/editar vivienda, detectado tras el merge del #27.

## Problemas

1. **El select no se percibía como control seleccionable.** Al sustituir los `<select>` nativos por `CustomSelect` (tarea F4) se le quitó la clase `.form-select`, dejándolo sin borde/fondo/padding: parecía texto plano.
2. **El desplegable se cortaba dentro de los acordeones** (p. ej. "Clasificación avanzada"): el `overflow: hidden` del `.form-accordion` (añadido en F2 para el redondeo) recortaba el dropdown `absolute` al sobresalir de la sección.

## Cambios

- `CustomSelect`: variante "boxed" **scopeada a `.property-create-page`** (borde, fondo, padding, valor alineado a la izquierda, placeholder atenuado, borde azul + `focus-ring` al abrir/enfocar) para que se vea como un input de formulario.
- Nueva clase `.custom-select-value--placeholder` para atenuar el texto de placeholder.
- `.form-accordion`: eliminado `overflow: hidden` para que el dropdown no se recorte.

`vite build` en verde. Nota: sin QA visual (el panel requiere Auth0 + Turso); es un arreglo razonado sobre el CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)